### PR TITLE
修复阅读界面异形屏会有小黑条的问题（如视频），Android15手机没有这个现象，可能跟Android15强制开启edge to edge有关

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -14,5 +14,6 @@
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
     <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>
 </resources>


### PR DESCRIPTION

https://github.com/user-attachments/assets/70a28244-5cee-4589-a206-b46c56003146

很棒的项目，另外有个小建议，阅读界面在index == 0的时候渲染了一个状态栏高度的Container，感觉有点破坏沉浸感，是否可以去掉