### PR TITLE
bug修复

### DIFF
--- a/lib/page/comic_info/view/comic_info.dart
+++ b/lib/page/comic_info/view/comic_info.dart
@@ -77,7 +77,7 @@ class _ComicInfoState extends State<_ComicInfo>
             .build()
             .findFirst();
 
-    if (comicHistory!.deleted) {
+    if (comicHistory?.deleted == true) {
       comicHistory = null;
     }
 
@@ -90,7 +90,7 @@ class _ComicInfoState extends State<_ComicInfo>
                   .query(BikaComicHistory_.comicId.equals(widget.comicId))
                   .build()
                   .findFirst();
-          if (comicHistory!.deleted) {
+          if (comicHistory?.deleted == true) {
             comicHistory = null;
           }
         });

--- a/lib/page/main.dart
+++ b/lib/page/main.dart
@@ -178,7 +178,7 @@ class _MainPageState extends State<MainPage> {
       ),
       PersistentBottomNavBarItem(
         icon: Icon(Icons.more_horiz),
-        title: "跟多",
+        title: "更多",
         activeColorPrimary: materialColorScheme.primary,
         inactiveColorPrimary: globalSetting.textColor,
       ),


### PR DESCRIPTION
修复一处非空断言导致的无法进入漫画详情页，如下图。对于没有阅读过的漫画，这里的comicHistory实际上会为null导致后续代码报错，可能测试的时候都选的已经阅读过的漫画所以没发现
![PixPin_2025-02-26_11-05-53](https://github.com/user-attachments/assets/c3967ad4-b44c-4559-a3cf-a9d0b4372b51)
