### PR TITLE
feat(reader): 章节选择对话框定位到当前章节并高亮

### DIFF
--- a/lib/page/comic_read/method/jump_chapter.dart
+++ b/lib/page/comic_read/method/jump_chapter.dart
@@ -178,4 +178,8 @@ class JumpChapter {
 
     return false;
   }
+
+  /// 用于章节选择对话框定位初始滚动位置
+  int currentChapterIndexIn(List<UnifiedComicChapterRef> refs) =>
+      refs.indexWhere(_matchesCurrentChapter);
 }

--- a/lib/page/comic_read/widgets/chrome/bottom.dart
+++ b/lib/page/comic_read/widgets/chrome/bottom.dart
@@ -225,21 +225,16 @@ class _BottomWidgetState extends State<BottomWidget> {
 
   Future<void> _selectJumpChapter() async {
     final router = AutoRouter.of(context);
+    final initialIndex = jumpChapter.currentChapterIndexIn(chapterRefs);
     final result = await showDialog<UnifiedComicChapterRef?>(
       context: context,
       barrierDismissible: false, // 不允许点击外部区域关闭对话框
       builder: (BuildContext context) {
-        return AlertDialog(
-          title: Text('选择章节'),
-          content: SingleChildScrollView(child: _epSelector(context)),
-          actions: [
-            TextButton(
-              child: Text('取消'),
-              onPressed: () {
-                context.pop();
-              },
-            ),
-          ],
+        return _ChapterPickerDialog(
+          refs: chapterRefs,
+          initialIndex: initialIndex,
+          onSelected: (ep) =>
+              Navigator.of(context, rootNavigator: false).pop(ep),
         );
       },
     );
@@ -263,16 +258,65 @@ class _BottomWidgetState extends State<BottomWidget> {
       );
     }
   }
+}
 
-  Widget _epSelector(BuildContext context) {
-    return ListBody(
-      children: [
-        for (final ep in chapterRefs)
-          TextButton(
-            child: Text(ep.name),
-            onPressed: () =>
-                Navigator.of(context, rootNavigator: false).pop(ep),
-          ),
+class _ChapterPickerDialog extends StatefulWidget {
+  final List<UnifiedComicChapterRef> refs;
+  final int initialIndex;
+  final ValueChanged<UnifiedComicChapterRef> onSelected;
+
+  const _ChapterPickerDialog({
+    required this.refs,
+    required this.initialIndex,
+    required this.onSelected,
+  });
+
+  @override
+  State<_ChapterPickerDialog> createState() => _ChapterPickerDialogState();
+}
+
+class _ChapterPickerDialogState extends State<_ChapterPickerDialog> {
+  late final List<GlobalKey> _itemKeys;
+
+  @override
+  void initState() {
+    super.initState();
+    _itemKeys = List.generate(widget.refs.length, (_) => GlobalKey());
+    if (widget.initialIndex < 0) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final context = _itemKeys[widget.initialIndex].currentContext;
+      if (context == null) return;
+      Scrollable.ensureVisible(context, alignment: 0.0);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final highlightStyle = TextButton.styleFrom(
+      foregroundColor: Theme.of(context).colorScheme.primary,
+    );
+
+    return AlertDialog(
+      title: const Text('选择章节'),
+      content: SingleChildScrollView(
+        child: ListBody(
+          children: [
+            for (var i = 0; i < widget.refs.length; i++)
+              TextButton(
+                key: _itemKeys[i],
+                style: i == widget.initialIndex ? highlightStyle : null,
+                child: Text(widget.refs[i].name),
+                onPressed: () => widget.onSelected(widget.refs[i]),
+              ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          child: const Text('取消'),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
       ],
     );
   }


### PR DESCRIPTION
## Summary

- 解决 #134：当前章节在列表中位置较深时（如 300+ 章漫画，正在阅读第 150 章），点击"跳转章节"后默认从第一章开始显示，需要反复滑动寻找当前章节
- 对话框打开时，自动滚动到**当前阅读章节**并作为视口顶部第一项（`Scrollable.ensureVisible` alignment: 0.0），用户可向上滑（更早章节）/ 向下滑（更后章节）双向浏览
- 当前章节用主题 `primary` 色染色高亮，便于识别

## 改动文件

| 文件 | 改动 |
|------|------|
| \`lib/page/comic_read/method/jump_chapter.dart\` | +4 行：新增 \`currentChapterIndexIn()\` public 方法，复用 \`_matchesCurrentChapter\` 的三层兜底匹配（logicalKey → requestId → chapterId/id） |
| \`lib/page/comic_read/widgets/chrome/bottom.dart\` | +68/-20 行：抽出私有 \`_ChapterPickerDialog\`，使用 \`Scrollable.ensureVisible\` 在首帧后定位当前章节；删除原 \`_epSelector\` 死代码 |

## 实现要点

- **不引入新依赖**，纯 Flutter 内置 API（\`Scrollable.ensureVisible\` + \`GlobalKey\` + post-frame callback）
- **边界处理**：
  - \`initialIndex < 0\`（extern 缺失等导致匹配失败）→ 静默回退到列表顶部，无报错
  - 列表为空 → 按钮已通过 \`isEnabled: chapterRefs.isNotEmpty\` 禁用，对话框不会打开（保持原行为）
  - 第一章 / 末章 → 正常工作
- **不影响范围**：仅触及 Dart UI 层，不修改 Rust / FRB / 路由 / 数据库。上一章 / 下一章 / 阅读滑块 / 阅读设置等独立代码路径完全不受影响

## Test plan

- [ ] 打开一本 30+ 章节（含番外更佳）的漫画，进入阅读页
- [ ] 用滑块或章节切换跳到中间章节（如第 150 章）
- [ ] 点击底部"跳转章节"图标
- [ ] 验证：对话框打开瞬间，视口顶部第一项为当前章节，文字用 primary 色高亮
- [ ] 验证：向上滑可见更早章节，向下滑可见后续章节
- [ ] 回归：当前章节为第 1 章 / 末章时表现正常
- [ ] 回归：点选任意章节能正常跳转阅读页（路由参数与改动前一致）
- [ ] 回归：点"取消"关闭对话框，阅读页状态不变
- [ ] 回归：上一章 / 下一章按钮行为与改动前完全一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)