### PR TITLE
修复无缝切章时跳转章节面板当前章高亮不更新

### DIFF
--- a/lib/page/comic_read/view/parts/comic_read_seamless_part.dart
+++ b/lib/page/comic_read/view/parts/comic_read_seamless_part.dart
@@ -1061,6 +1061,14 @@ extension _ComicReadSeamlessPart on _ComicReadPageState {
       _jumpChapter.haveNext = false;
       return;
     }
+    // 同步身份字段：滑到章末自动切章时，"跳转章节"面板靠这些字段
+    // 判定当前章节高亮，缺失则永远停在进入阅读器时的那一章
+    final chapter = chapters[index];
+    _jumpChapter.chapterId = resolveUnifiedComicChapterKey(chapter);
+    _jumpChapter.requestId = chapter.requestId.trim();
+    _jumpChapter.storageChapterId = chapter.storageChapterId.trim();
+    _jumpChapter.logicalKey = chapter.logicalKey.trim();
+    _jumpChapter.chapterExtern = Map<String, dynamic>.from(chapter.extern);
     _jumpChapter.havePrev = index > 0;
     _jumpChapter.haveNext = index < chapters.length - 1;
   }


### PR DESCRIPTION
## 问题

阅读时，若不通过「跳转章节」按钮切换，而是在每章末尾向下滑动自动进入下一章（无缝拼接模式），「跳转章节」面板里显示的当前章节高亮不会更新。连续滑过 N 章后，面板显示的当前章与实际所在章可相差 N 章。

## 根因

无缝切章走 `_applyCurrentChapterByGlobalSlot` → `_syncJumpChapterState`（`lib/page/comic_read/view/parts/comic_read_seamless_part.dart`），但该函数只同步了 `order / havePrev / haveNext`，未同步 `chapterId / requestId / storageChapterId / logicalKey / chapterExtern` 等身份字段。

而「跳转章节」面板判定当前章高亮用的是 `JumpChapter._matchesCurrentChapter`（`lib/page/comic_read/method/jump_chapter.dart`），匹配条件正是 `logicalKey / requestId / chapterId`。因此高亮永远停留在进入阅读器时的那一章。

## 修复

在 `_syncJumpChapterState` 中按 `order` 定位到 catalog 章节后，参照同项目 `JumpChapter.jumpToChapter` 的写法，将身份字段一并写回 `_jumpChapter`，使面板能正确识别当前章节。

## 验证

- `flutter analyze` 通过，无新增告警
- Windows 编译通过
- 实机测试：滑到章末自动切章后，「跳转章节」面板当前章高亮正确跟随