### PR TITLE
修复插件更新与商店 UI（#147）

### DIFF
--- a/lib/object_box/model.dart
+++ b/lib/object_box/model.dart
@@ -991,6 +991,9 @@ class PluginInfo {
 
   String? debugUrl;
 
+  // 安装来源：local / network / cloud，用于「已安装」卡片更新提示
+  String installSource;
+
   PluginInfo({
     this.id = 0,
     required this.uuid,
@@ -1005,6 +1008,7 @@ class PluginInfo {
     this.lastLoadError,
     required this.debug,
     this.debugUrl,
+    this.installSource = '',
   });
 
   Map<String, dynamic> toJson() => _$PluginInfoToJson(this);

--- a/lib/object_box/model.g.dart
+++ b/lib/object_box/model.g.dart
@@ -684,6 +684,7 @@ PluginInfo _$PluginInfoFromJson(Map<String, dynamic> json) => PluginInfo(
   lastLoadError: json['lastLoadError'] as String?,
   debug: json['debug'] as bool,
   debugUrl: json['debugUrl'] as String?,
+  installSource: json['installSource'] as String? ?? '',
 );
 
 Map<String, dynamic> _$PluginInfoToJson(PluginInfo instance) =>
@@ -701,6 +702,7 @@ Map<String, dynamic> _$PluginInfoToJson(PluginInfo instance) =>
       'deletedAt': instance.deletedAt?.toIso8601String(),
       'debug': instance.debug,
       'debugUrl': instance.debugUrl,
+      'installSource': instance.installSource,
     };
 
 ComicFolder _$ComicFolderFromJson(Map<String, dynamic> json) => ComicFolder(

--- a/lib/object_box/objectbox-model.json
+++ b/lib/object_box/objectbox-model.json
@@ -942,7 +942,7 @@
     },
     {
       "id": "12:5269818584842768822",
-      "lastPropertyId": "18:4398518863020863280",
+      "lastPropertyId": "19:6873052902821237964",
       "name": "PluginInfo",
       "properties": [
         {
@@ -1011,6 +1011,11 @@
         {
           "id": "18:4398518863020863280",
           "name": "originScript",
+          "type": 9
+        },
+        {
+          "id": "19:6873052902821237964",
+          "name": "installSource",
           "type": 9
         }
       ],

--- a/lib/object_box/objectbox.g.dart
+++ b/lib/object_box/objectbox.g.dart
@@ -1140,7 +1140,7 @@ final _entities = <obx_int.ModelEntity>[
   obx_int.ModelEntity(
     id: const obx_int.IdUid(12, 5269818584842768822),
     name: 'PluginInfo',
-    lastPropertyId: const obx_int.IdUid(18, 4398518863020863280),
+    lastPropertyId: const obx_int.IdUid(19, 6873052902821237964),
     flags: 0,
     properties: <obx_int.ModelProperty>[
       obx_int.ModelProperty(
@@ -1219,6 +1219,12 @@ final _entities = <obx_int.ModelEntity>[
       obx_int.ModelProperty(
         id: const obx_int.IdUid(18, 4398518863020863280),
         name: 'originScript',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(19, 6873052902821237964),
+        name: 'installSource',
         type: 9,
         flags: 0,
       ),
@@ -3522,7 +3528,8 @@ obx_int.ModelDefinition getObjectBoxModel() {
             ? null
             : fbb.writeString(object.debugUrl!);
         final originScriptOffset = fbb.writeString(object.originScript);
-        fbb.startTable(19);
+        final installSourceOffset = fbb.writeString(object.installSource);
+        fbb.startTable(20);
         fbb.addInt64(0, object.id);
         fbb.addOffset(4, versionOffset);
         fbb.addInt64(7, object.insertedAt.millisecondsSinceEpoch);
@@ -3536,6 +3543,7 @@ obx_int.ModelDefinition getObjectBoxModel() {
         fbb.addBool(15, object.debug);
         fbb.addOffset(16, debugUrlOffset);
         fbb.addOffset(17, originScriptOffset);
+        fbb.addOffset(18, installSourceOffset);
         fbb.finish(fbb.endTable());
         return object.id;
       },
@@ -3601,6 +3609,9 @@ obx_int.ModelDefinition getObjectBoxModel() {
         final debugUrlParam = const fb.StringReader(
           asciiOptimization: true,
         ).vTableGetNullable(buffer, rootOffset, 36);
+        final installSourceParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGet(buffer, rootOffset, 40, '');
         final object = PluginInfo(
           id: idParam,
           uuid: uuidParam,
@@ -3615,6 +3626,7 @@ obx_int.ModelDefinition getObjectBoxModel() {
           lastLoadError: lastLoadErrorParam,
           debug: debugParam,
           debugUrl: debugUrlParam,
+          installSource: installSourceParam,
         );
 
         return object;
@@ -5469,6 +5481,11 @@ class PluginInfo_ {
   /// See [PluginInfo.originScript].
   static final originScript = obx.QueryStringProperty<PluginInfo>(
     _entities[8].properties[12],
+  );
+
+  /// See [PluginInfo.installSource].
+  static final installSource = obx.QueryStringProperty<PluginInfo>(
+    _entities[8].properties[13],
   );
 }
 

--- a/lib/page/discover/view/discover_page.dart
+++ b/lib/page/discover/view/discover_page.dart
@@ -410,10 +410,6 @@ class _DiscoverPageState extends State<DiscoverPage> {
                     );
                   },
                 ),
-                Switch(
-                  value: isEnabled,
-                  onChanged: (val) => _togglePluginEnabled(pluginUuid, val),
-                ),
               ],
             ),
           ),
@@ -473,10 +469,6 @@ class _DiscoverPageState extends State<DiscoverPage> {
         ],
       ),
     );
-  }
-
-  Future<void> _togglePluginEnabled(String uuid, bool enabled) async {
-    await PluginRegistryService.I.setEnabled(uuid, enabled);
   }
 
   void _reconcilePluginInfoCache(Map<String, PluginRuntimeState> pluginStates) {

--- a/lib/page/plugin_store/cubit/plugin_store_cubit.dart
+++ b/lib/page/plugin_store/cubit/plugin_store_cubit.dart
@@ -137,6 +137,7 @@ class PluginStoreCubit extends Cubit<PluginStoreState> {
         script,
         sourceLabel: '云端组件: ${item.repo}',
         allowReplaceExisting: true,
+        installSource: 'cloud',
       );
     } catch (e) {
       _reportInstallFailure('云端下载失败: $e');
@@ -208,7 +209,12 @@ class PluginStoreCubit extends Cubit<PluginStoreState> {
         bytes: bytes,
         shouldUseBrotli: fileName.toLowerCase().endsWith('.br'),
       );
-      await _savePluginByScript(script, sourceLabel: '本地文件: $fileName');
+      await _savePluginByScript(
+        script,
+        sourceLabel: '本地文件: $fileName',
+        allowReplaceExisting: true,
+        installSource: 'local',
+      );
     } catch (e) {
       _reportInstallFailure('读取本地插件失败: $e');
     }
@@ -235,9 +241,46 @@ class PluginStoreCubit extends Cubit<PluginStoreState> {
         response: response,
         resolvedUrl: resolvedUrl,
       );
-      await _savePluginByScript(script, sourceLabel: '网络地址: $resolvedUrl');
+      await _savePluginByScript(
+        script,
+        sourceLabel: '网络地址: $resolvedUrl',
+        allowReplaceExisting: true,
+        installSource: 'network',
+      );
     } catch (e) {
       _reportInstallFailure('网络下载插件失败: $e');
+    }
+  }
+
+  /// 「已安装」卡片更新入口。updateUrl 通常是 GitHub release API，
+  /// 复用云端组件的解析下载逻辑（_downloadFromJsdelivrOrGitHub），
+  /// 而非 installFromNetworkUrl（它只处理脚本直链，会把 release JSON 当脚本解析报错）。
+  /// installSource 留空以保留最初安装来源。
+  Future<void> updateFromUrl(String updateUrl) async {
+    if (state.installing) {
+      return;
+    }
+    final resolvedUrl = updateUrl.trim();
+    if (resolvedUrl.isEmpty) {
+      _reportInstallFailure('URL 不能为空');
+      return;
+    }
+
+    _beginInstall('正在更新插件...');
+
+    try {
+      final script = await _downloadFromJsdelivrOrGitHub(
+        npmName: '',
+        cloudVersion: '',
+        updateUrl: resolvedUrl,
+      );
+      await _savePluginByScript(
+        script,
+        sourceLabel: '更新: $resolvedUrl',
+        allowReplaceExisting: true,
+      );
+    } catch (e) {
+      _reportInstallFailure('更新失败: $e');
     }
   }
 
@@ -455,6 +498,7 @@ class PluginStoreCubit extends Cubit<PluginStoreState> {
   Future<void> _savePluginByScript(
     String script, {
     required String sourceLabel,
+    String installSource = '',
     bool allowReplaceExisting = false,
   }) async {
     final normalizedScript = script.trim();
@@ -481,6 +525,10 @@ class PluginStoreCubit extends Cubit<PluginStoreState> {
 
       final now = DateTime.now().toUtc();
       final existingInfo = _findExistingPluginInfoByUuid(resolvedUuid);
+      // installSource 留空表示更新，保留最初安装来源（本地插件更新后仍记为本地）
+      final effectiveInstallSource = installSource.isNotEmpty
+          ? installSource
+          : (existingInfo?.installSource ?? '');
       final infoToSave = PluginInfo(
         id: existingInfo?.id ?? 0,
         uuid: resolvedUuid,
@@ -495,6 +543,7 @@ class PluginStoreCubit extends Cubit<PluginStoreState> {
         lastLoadError: null,
         debug: existing?.debug ?? false,
         debugUrl: existing?.debugUrl,
+        installSource: effectiveInstallSource,
       );
 
       await PluginRegistryService.I.upsert(infoToSave);

--- a/lib/page/plugin_store/view/plugin_store_page.dart
+++ b/lib/page/plugin_store/view/plugin_store_page.dart
@@ -3,9 +3,12 @@ import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:zephyr/cubit/plugin_registry_cubit.dart';
 import 'package:zephyr/page/plugin_store/cubit/plugin_store_cubit.dart';
 import 'package:zephyr/page/plugin_store/widgets/cloud_plugin_card.dart';
+import 'package:zephyr/page/plugin_store/widgets/installed_plugin_card.dart';
 import 'package:zephyr/page/plugin_store/widgets/plugin_store_status_banner.dart';
+import 'package:zephyr/plugin/plugin_registry_service.dart';
 import 'package:zephyr/widgets/toast.dart';
 
 @RoutePage()
@@ -52,6 +55,7 @@ class _PluginStorePageContentState extends State<_PluginStorePageContent> {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final pluginStates = context.watch<PluginRegistryCubit>().state;
     return BlocBuilder<PluginStoreCubit, PluginStoreState>(
       builder: (context, state) {
         return Scaffold(
@@ -67,6 +71,7 @@ class _PluginStorePageContentState extends State<_PluginStorePageContent> {
                   const SizedBox(height: 14),
                   _buildInstallButtons(state.installing),
                   const SizedBox(height: 16),
+                  _buildInstalledPluginsSection(state, pluginStates),
                   _buildCloudPluginsSection(state),
                 ],
               ),
@@ -74,6 +79,40 @@ class _PluginStorePageContentState extends State<_PluginStorePageContent> {
           ),
         );
       },
+    );
+  }
+
+  Widget _buildInstalledPluginsSection(
+    PluginStoreState state,
+    Map<String, PluginRuntimeState> pluginStates,
+  ) {
+    final installed = pluginStates.values.where((s) => !s.isDeleted).toList()
+      ..sort((a, b) => a.insertedAt.compareTo(b.insertedAt));
+    if (installed.isEmpty) return const SizedBox.shrink();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            const Icon(Icons.download_done_outlined, size: 18),
+            const SizedBox(width: 8),
+            Text('已安装', style: Theme.of(context).textTheme.titleMedium),
+          ],
+        ),
+        const SizedBox(height: 8),
+        for (final s in installed)
+          InstalledPluginCard(
+            key: ValueKey(s.uuid),
+            pluginUuid: s.uuid,
+            isEnabled: s.isEnabled,
+            version: s.version,
+            installSource: s.installSource,
+            installing: state.installing,
+            onOpenHome: _openExternalUrl,
+          ),
+        const SizedBox(height: 16),
+      ],
     );
   }
 
@@ -122,6 +161,12 @@ class _PluginStorePageContentState extends State<_PluginStorePageContent> {
     final colorScheme = Theme.of(context).colorScheme;
     final query = _searchController.text.trim().toLowerCase();
     final displayPlugins = state.cloudPlugins.where((item) {
+      // 已安装的插件移至「已安装」板块，云端组件不再重复展示
+      final uuid = item.manifest.uuid;
+      final local = uuid.isEmpty
+          ? null
+          : PluginRegistryService.I.getByUuid(uuid);
+      if (local != null && !local.isDeleted) return false;
       if (query.isEmpty) return true;
       final name = item.manifest.name.toLowerCase();
       final creator = item.manifest.creatorName.toLowerCase();

--- a/lib/page/plugin_store/widgets/installed_plugin_card.dart
+++ b/lib/page/plugin_store/widgets/installed_plugin_card.dart
@@ -1,0 +1,253 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:zephyr/page/plugin_store/cubit/plugin_store_cubit.dart';
+import 'package:zephyr/plugin/plugin_registry_service.dart';
+
+/// 「已安装」插件卡片：展示主页 / 更新 / 启用开关。
+///
+/// 主页与更新 URL 来自插件脚本 getInfo()（fetchPluginInfo），
+/// 与网络安装配置同源；updateUrl 为空则不显示更新按钮（走顶部「本地安装」覆盖）。
+class InstalledPluginCard extends StatefulWidget {
+  const InstalledPluginCard({
+    super.key,
+    required this.pluginUuid,
+    required this.isEnabled,
+    required this.version,
+    required this.installSource,
+    required this.installing,
+    required this.onOpenHome,
+  });
+
+  final String pluginUuid;
+  final bool isEnabled;
+  final String version;
+  final String installSource;
+  final bool installing;
+  final ValueChanged<String> onOpenHome;
+
+  @override
+  State<InstalledPluginCard> createState() => _InstalledPluginCardState();
+}
+
+class _InstalledPluginCardState extends State<InstalledPluginCard> {
+  Future<Map<String, dynamic>>? _infoFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _infoFuture = PluginRegistryService.I.fetchPluginInfo(
+      uuid: widget.pluginUuid,
+      runtimeName: widget.pluginUuid,
+    );
+  }
+
+  @override
+  void didUpdateWidget(covariant InstalledPluginCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // 列表变化时防止 State 复用导致 uuid 与缓存 info 错位
+    if (oldWidget.pluginUuid != widget.pluginUuid) {
+      _infoFuture = PluginRegistryService.I.fetchPluginInfo(
+        uuid: widget.pluginUuid,
+        runtimeName: widget.pluginUuid,
+      );
+    }
+  }
+
+  // 仅本地安装插件提示：网络更新会覆盖本地脚本，本地更新请走顶部「本地安装」
+  Future<void> _triggerNetworkUpdate(String updateUrl) async {
+    if (widget.installSource == 'local') {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (context) => AlertDialog(
+          content: const Text('使用网络更新，本地更新请使用「本地安装」覆盖'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('取消'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('确定'),
+            ),
+          ],
+        ),
+      );
+      if (confirmed != true || !mounted) return;
+    }
+    await context.read<PluginStoreCubit>().updateFromUrl(updateUrl);
+  }
+
+  Future<void> _confirmUninstall() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        content: const Text('确认卸载该插件？将同时移除其数据。'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('取消'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('卸载'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true && mounted) {
+      await PluginRegistryService.I.deletePlugin(widget.pluginUuid);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return FutureBuilder<Map<String, dynamic>>(
+      future: _infoFuture,
+      builder: (context, snapshot) {
+        final info = snapshot.data ?? const <String, dynamic>{};
+        final name = info['name']?.toString().trim() ?? '';
+        final iconUrl = info['iconUrl']?.toString().trim() ?? '';
+        final describe = info['describe']?.toString().trim() ?? '';
+        final home = info['home']?.toString().trim() ?? '';
+        final updateUrl = info['updateUrl']?.toString().trim() ?? '';
+        final title = name.isNotEmpty ? name : widget.pluginUuid;
+
+        return Opacity(
+          opacity: widget.isEnabled ? 1.0 : 0.6,
+          child: Container(
+            margin: const EdgeInsets.only(bottom: 10),
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(12),
+              color: colorScheme.surface.withValues(alpha: 0.85),
+              border: Border.all(
+                color: colorScheme.outlineVariant.withValues(alpha: 0.6),
+              ),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _InstalledIcon(iconUrl: iconUrl),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            title,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: Theme.of(context).textTheme.titleSmall,
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            '版本 ${widget.version}',
+                            style: Theme.of(context).textTheme.bodySmall
+                                ?.copyWith(color: colorScheme.onSurfaceVariant),
+                          ),
+                          if (describe.isNotEmpty) ...[
+                            const SizedBox(height: 4),
+                            Text(
+                              describe,
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                              style: Theme.of(context).textTheme.bodySmall,
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 10),
+                Row(
+                  children: [
+                    if (home.isNotEmpty)
+                      OutlinedButton.icon(
+                        onPressed: widget.installing
+                            ? null
+                            : () => widget.onOpenHome(home),
+                        icon: const Icon(Icons.open_in_new, size: 16),
+                        label: const Text('主页'),
+                      ),
+                    if (home.isNotEmpty) const SizedBox(width: 8),
+                    if (updateUrl.isNotEmpty)
+                      OutlinedButton.icon(
+                        onPressed: widget.installing
+                            ? null
+                            : () => _triggerNetworkUpdate(updateUrl),
+                        icon: const Icon(Icons.download_outlined, size: 16),
+                        label: const Text('更新'),
+                      ),
+                    if (updateUrl.isNotEmpty) const SizedBox(width: 8),
+                    OutlinedButton.icon(
+                      onPressed: widget.installing ? null : _confirmUninstall,
+                      icon: Icon(
+                        Icons.delete_outline,
+                        size: 16,
+                        color: colorScheme.error,
+                      ),
+                      label: Text(
+                        '卸载',
+                        style: TextStyle(color: colorScheme.error),
+                      ),
+                    ),
+                    const Spacer(),
+                    Switch(
+                      value: widget.isEnabled,
+                      onChanged: widget.installing
+                          ? null
+                          : (val) => PluginRegistryService.I.setEnabled(
+                              widget.pluginUuid,
+                              val,
+                            ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _InstalledIcon extends StatelessWidget {
+  const _InstalledIcon({required this.iconUrl});
+
+  final String iconUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(8),
+      child: Container(
+        width: 40,
+        height: 40,
+        color: colorScheme.surfaceContainerHigh,
+        alignment: Alignment.center,
+        child: iconUrl.trim().isEmpty
+            ? Icon(
+                Icons.extension_outlined,
+                size: 20,
+                color: colorScheme.onSurfaceVariant,
+              )
+            : Image.network(
+                iconUrl,
+                fit: BoxFit.cover,
+                errorBuilder: (_, _, _) => Icon(
+                  Icons.extension_outlined,
+                  size: 20,
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+      ),
+    );
+  }
+}

--- a/lib/plugin/plugin_registry_service.dart
+++ b/lib/plugin/plugin_registry_service.dart
@@ -31,6 +31,7 @@ class PluginRuntimeState {
     required this.insertedAt,
     required this.updatedAt,
     required this.deletedAt,
+    required this.installSource,
   });
 
   final String uuid;
@@ -45,6 +46,7 @@ class PluginRuntimeState {
   final DateTime insertedAt;
   final DateTime updatedAt;
   final DateTime? deletedAt;
+  final String installSource;
 
   bool get isActive => isEnabled && !isDeleted;
 
@@ -74,6 +76,7 @@ class PluginRuntimeState {
       insertedAt: insertedAt ?? this.insertedAt,
       updatedAt: updatedAt ?? this.updatedAt,
       deletedAt: deletedAt,
+      installSource: installSource,
     );
   }
 }
@@ -1155,6 +1158,7 @@ class PluginRegistryService {
       insertedAt: item.insertedAt,
       updatedAt: item.updatedAt,
       deletedAt: item.deletedAt,
+      installSource: item.installSource,
     );
   }
 


### PR DESCRIPTION
Fixes #147

## 背景
「网络安装」的插件无法更新，必须彻底卸载（含数据）才能重装；网络/本地/云端组件管理混乱。

**根因**：`installFromNetworkUrl` / `installFromLocalBytes` 调 `_savePluginByScript` 未传 `allowReplaceExisting`（默认 false），重装同 UUID 插件在 `_validateUuidNotDuplicated` 抛「插件已存在」。仅 `installFromCloud` 传 true。

## 改动

### 逻辑修复
- 网络/本地安装传 `allowReplaceExisting: true` → 重装覆盖更新，不再报「重复插件」

### UI 重构
- 插件商店新增「已安装」板块（云端组件前）；已安装插件从「云端组件」移除
- 已安装卡片：主页 / 更新 / 卸载 / 启用开关
- discover 卡片移除启用开关（统一到插件商店管理）

### 更新逻辑
- 新增 \`updateFromUrl\`：复用云端组件的 \`_downloadFromJsdelivrOrGitHub\`（解析 GitHub release API），修复 release URL 被当脚本直链解析报错（\"expecting ';'\"）
- 仅本地安装插件更新弹确认框（\"使用网络更新，本地更新请使用「本地安装」覆盖\"）
- 更新保留最初安装来源（installSource），主页/更新 URL 来自插件脚本 \`getInfo()\`

### 数据模型
- \`PluginInfo\` / \`PluginRuntimeState\` 新增 \`installSource\`（local/network/cloud）
- \`InstalledPluginCard\` 加 \`ValueKey\` 防 State 复用导致卸载错位

## 验证
- \`flutter analyze\` 干净
- Windows 编译通过
- 实机测试：网络安装覆盖更新、板块展示、卸载正确、更新走 release API、启用开关均正常