### PR TITLE
fix(readme): 修复 Star History 图表链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,8 @@ AltStore 是目前最稳定且对新手友好的 iOS 侧载工具，支持通过
 
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=deretame/Breeze&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=deretame/Breeze&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=deretame/Breeze&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=deretame/Breeze&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=deretame/Breeze&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=deretame/Breeze&type=Date" />
   </picture>
 </p>


### PR DESCRIPTION
README 中的 Star History 图表目前已失效，原因是 GitHub stargazer API 的限制。本 MR 将图表链接更新为替代方案 star-history.dera.page，该方案无需 API token 即可正常渲染图表，帮助恢复项目星标趋势展示。