### PR TITLE
fix(system_tray): support Linux/macOS system tray

### DIFF
--- a/lib/platform/desktop/system_tray.dart
+++ b/lib/platform/desktop/system_tray.dart
@@ -5,10 +5,13 @@ import 'package:zephyr/i18n/strings.g.dart';
 import 'package:zephyr/main.dart';
 
 Future<void> initSystemTray() async {
-  if (!Platform.isWindows) return;
+  if (!Platform.isWindows && !Platform.isLinux && !Platform.isMacOS) return;
 
   try {
-    await trayManager.setIcon('asset/image/app_icon.ico');
+    final iconPath = Platform.isWindows
+        ? 'asset/image/app_icon.ico'
+        : 'asset/image/app-icon.png';
+    await trayManager.setIcon(iconPath);
     await trayManager.setToolTip('Zephyr');
 
     Menu menu = Menu(


### PR DESCRIPTION
Linux/macOS 版此前完全跳过系统托盘初始化（`if (!Platform.isWindows) return;`），导致 Flatpak 分发的 Linux 版没有托盘图标。

- 移除 Windows 限定，允许 Linux（StatusNotifierItem/appindicator）与 macOS（NSStatusItem）初始化托盘
- Linux 的 appindicator 经 GdkPixbuf 加载图标不支持 .ico，改用 asset/image/app-icon.png

Flatpak manifest 已放行 `org.kde.StatusNotifierWatcher` 总线且打包了 libayatana-appindicator，此修复后 Linux 托盘即可正常显示。