### PR TITLE
fix(linux): 托盘与关闭行为修复、WebDAV 解析修复，新增 .deb 打包

### DIFF
--- a/.github/workflows/push-build.yml
+++ b/.github/workflows/push-build.yml
@@ -215,6 +215,17 @@ jobs:
           name: linux-flatpak
           path: breeze.flatpak
 
+      - name: 构建 Linux .deb
+        run: |
+          sudo apt-get install -y dpkg-dev
+          fvm dart ./script/build_linux_deb.dart --package-only
+
+      - name: 上传 Linux deb
+        uses: actions/upload-artifact@v6
+        with:
+          name: linux-deb
+          path: build-deb/breeze_*.deb
+
   # ══════════════════════════════════════════
   # 3. Windows 构建
   # ══════════════════════════════════════════

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -487,6 +487,14 @@ class _MyAppState extends State<MyApp>
     trayManager.addListener(this);
     initSystemTray();
 
+    if (Platform.isLinux) {
+      _linuxWindowChannel.setMethodCallHandler((call) async {
+        if (call.method == 'windowCloseRequested') {
+          _handleCloseRequest();
+        }
+      });
+    }
+
     // 启动命名管道监听，用于接收外部退出信号（仅 Windows）
     if (Platform.isWindows) {
       rust_system.startShutdownListener().listen((shouldExit) {
@@ -554,8 +562,20 @@ class _MyAppState extends State<MyApp>
     nuclearKillProcess();
   }
 
+  bool _handlingCloseRequest = false;
+
+  static const MethodChannel _linuxWindowChannel =
+      MethodChannel('breeze/linux/window');
+
   @override
-  void onWindowClose() async {
+  void onWindowClose() {
+    _handleCloseRequest();
+  }
+
+  Future<void> _handleCloseRequest() async {
+    if (_handlingCloseRequest) return;
+    _handlingCloseRequest = true;
+    try {
     final closeBehavior = await WindowLogic.loadCloseBehavior();
     switch (closeBehavior) {
       case DesktopCloseBehavior.hide:
@@ -636,6 +656,9 @@ class _MyAppState extends State<MyApp>
         );
       },
     );
+    } finally {
+      _handlingCloseRequest = false;
+    }
   }
 
   /// 隐藏窗口到任务栏托盘，不退出程序

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -556,6 +556,12 @@ class _MyAppState extends State<MyApp>
 
   @override
   void onWindowClose() async {
+    // Linux 上托盘(AppIndicator)与各桌面环境行为差异大，点 X 一律直接退出进程，
+    // 忽略"隐藏到托盘"等设置，避免出现关不掉/找不到窗口的情况
+    if (Platform.isLinux) {
+      await _forceExit();
+      return;
+    }
     final closeBehavior = await WindowLogic.loadCloseBehavior();
     switch (closeBehavior) {
       case DesktopCloseBehavior.hide:

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -588,6 +588,9 @@ class _MyAppState extends State<MyApp>
         break;
     }
 
+    if (Platform.isLinux) {
+      await windowManager.show();
+    }
     final dialogContext = appRouter.navigatorKey.currentContext;
     if (dialogContext == null || !dialogContext.mounted) {
       await _forceExit();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -556,8 +556,6 @@ class _MyAppState extends State<MyApp>
 
   @override
   void onWindowClose() async {
-    // Linux 上托盘(AppIndicator)与各桌面环境行为差异大，点 X 一律直接退出进程，
-    // 忽略"隐藏到托盘"等设置，避免出现关不掉/找不到窗口的情况
     if (Platform.isLinux) {
       await _forceExit();
       return;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -660,7 +660,7 @@ class _MyAppState extends State<MyApp>
 
   @override
   void onTrayIconMouseDown() {
-    NativeWindow.show();
+    showMainWindow();
   }
 
   @override
@@ -671,7 +671,7 @@ class _MyAppState extends State<MyApp>
   @override
   void onTrayMenuItemClick(MenuItem menuItem) {
     if (menuItem.key == 'show_window') {
-      NativeWindow.show();
+      showMainWindow();
     } else if (menuItem.key == 'exit_app') {
       // 真正退出：清理资源后退出
       _performGracefulExit();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -556,10 +556,6 @@ class _MyAppState extends State<MyApp>
 
   @override
   void onWindowClose() async {
-    if (Platform.isLinux) {
-      await _forceExit();
-      return;
-    }
     final closeBehavior = await WindowLogic.loadCloseBehavior();
     switch (closeBehavior) {
       case DesktopCloseBehavior.hide:

--- a/lib/platform/desktop/system_tray.dart
+++ b/lib/platform/desktop/system_tray.dart
@@ -1,8 +1,17 @@
 import 'dart:io';
 
 import 'package:tray_manager/tray_manager.dart';
+import 'package:window_manager/window_manager.dart';
 import 'package:zephyr/i18n/strings.g.dart';
 import 'package:zephyr/main.dart';
+import 'package:zephyr/platform/desktop/native_window.dart';
+
+bool _runningInSandbox() {
+  return Platform.environment.containsKey('FLATPAK_ID') ||
+      Platform.environment.containsKey('SNAP') ||
+      (Platform.environment['container']?.isNotEmpty ?? false) ||
+      File('/.dockerenv').existsSync();
+}
 
 Future<void> initSystemTray() async {
   if (!Platform.isWindows && !Platform.isLinux && !Platform.isMacOS) return;
@@ -10,21 +19,36 @@ Future<void> initSystemTray() async {
   try {
     final iconPath = Platform.isWindows
         ? 'asset/image/app_icon.ico'
-        : 'asset/image/app-icon.png';
+        : (Platform.isLinux && _runningInSandbox())
+              ? 'io.github.windy.breeze'
+              : 'asset/image/app-icon.png';
     await trayManager.setIcon(iconPath);
-    await trayManager.setToolTip('Zephyr');
 
-    Menu menu = Menu(
+    final Menu menu = Menu(
       items: [
         MenuItem(key: 'show_window', label: t.settings.showMainWindow),
         MenuItem.separator(),
         MenuItem(key: 'exit_app', label: t.settings.exitApp),
       ],
     );
-
     await trayManager.setContextMenu(menu);
+
+    try {
+      await trayManager.setToolTip('Zephyr');
+    } catch (e) {
+      logger.d('setToolTip is unsupported on this platform: $e');
+    }
     logger.d('System tray initialized successfully');
   } catch (e, stack) {
     logger.e('Failed to init system tray: $e', error: e, stackTrace: stack);
+  }
+}
+
+Future<void> showMainWindow() async {
+  if (Platform.isWindows) {
+    NativeWindow.show();
+  } else {
+    await windowManager.show();
+    await windowManager.focus();
   }
 }

--- a/lib/widgets/desktop/custom_title_bar.dart
+++ b/lib/widgets/desktop/custom_title_bar.dart
@@ -61,8 +61,6 @@ class _CustomTitleBarState extends State<CustomTitleBar> with WindowListener {
   void _handleClose() {
     if (Platform.isWindows) {
       NativeWindow.close();
-    } else if (Platform.isLinux) {
-      exit(0);
     } else {
       windowManager.close();
     }

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -59,7 +59,6 @@ static void my_application_activate(GApplication* application) {
 #endif
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
-    gtk_widget_realize(GTK_WIDGET(window));
     gtk_header_bar_set_title(header_bar, "zephyr");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
@@ -89,14 +88,14 @@ static void my_application_activate(GApplication* application) {
                            self);
   gtk_widget_realize(GTK_WIDGET(view));
 
-  fl_register_plugins(FL_PLUGIN_REGISTRY(view));
-
   FlEngine* engine = fl_view_get_engine(view);
   self->window_channel = fl_method_channel_new(
       fl_engine_get_binary_messenger(engine), "breeze/linux/window",
       FL_METHOD_CODEC(fl_standard_method_codec_new()));
   g_signal_connect(window, "delete_event", G_CALLBACK(on_window_delete_event),
                    self);
+
+  fl_register_plugins(FL_PLUGIN_REGISTRY(view));
 
   gtk_widget_grab_focus(GTK_WIDGET(view));
 }

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -24,7 +24,6 @@ static gboolean on_window_delete_event(GtkWidget* widget,
                                        GdkEvent* event,
                                        gpointer user_data) {
   MyApplication* self = MY_APPLICATION(user_data);
-  g_warning("breeze: window close intercepted");
   gtk_widget_hide(widget);
   if (self->window_channel != nullptr) {
     fl_method_channel_invoke_method(self->window_channel,

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -10,6 +10,7 @@
 struct _MyApplication {
   GtkApplication parent_instance;
   char** dart_entrypoint_arguments;
+  FlMethodChannel* window_channel;
 };
 
 G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
@@ -17,6 +18,18 @@ G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
 // Called when first Flutter frame received.
 static void first_frame_cb(MyApplication* self, FlView* view) {
   gtk_widget_show(gtk_widget_get_toplevel(GTK_WIDGET(view)));
+}
+
+static gboolean on_window_delete_event(GtkWidget* widget,
+                                       GdkEvent* event,
+                                       gpointer user_data) {
+  MyApplication* self = MY_APPLICATION(user_data);
+  if (self->window_channel != nullptr) {
+    fl_method_channel_invoke_method(self->window_channel,
+                                    "windowCloseRequested", nullptr, nullptr,
+                                    nullptr, nullptr);
+  }
+  return TRUE;
 }
 
 // Implements GApplication::activate.
@@ -76,6 +89,13 @@ static void my_application_activate(GApplication* application) {
 
   fl_register_plugins(FL_PLUGIN_REGISTRY(view));
 
+  FlEngine* engine = fl_view_get_engine(view);
+  self->window_channel = fl_method_channel_new(
+      fl_engine_get_binary_messenger(engine), "breeze/linux/window",
+      FL_METHOD_CODEC(fl_standard_method_codec_new()));
+  g_signal_connect(window, "delete_event", G_CALLBACK(on_window_delete_event),
+                   self);
+
   gtk_widget_grab_focus(GTK_WIDGET(view));
 }
 
@@ -122,6 +142,7 @@ static void my_application_shutdown(GApplication* application) {
 static void my_application_dispose(GObject* object) {
   MyApplication* self = MY_APPLICATION(object);
   g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
+  g_clear_object(&self->window_channel);
   G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
 }
 

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -24,6 +24,8 @@ static gboolean on_window_delete_event(GtkWidget* widget,
                                        GdkEvent* event,
                                        gpointer user_data) {
   MyApplication* self = MY_APPLICATION(user_data);
+  g_warning("breeze: window close intercepted");
+  gtk_widget_hide(widget);
   if (self->window_channel != nullptr) {
     fl_method_channel_invoke_method(self->window_channel,
                                     "windowCloseRequested", nullptr, nullptr,

--- a/rust/src/api/webdav.rs
+++ b/rust/src/api/webdav.rs
@@ -98,8 +98,64 @@ impl WebDavClient {
             return Err(WebDavStatusError(status.as_u16()).into());
         }
         let body = response.text().await?;
-        Ok(serde_xml_rs::from_str::<ListMultiStatus>(&body)?.responses)
+        Ok(
+            serde_xml_rs::from_str::<ListMultiStatus>(&strip_xml_ns(&body))?
+                .responses,
+        )
     }
+}
+
+fn strip_xml_ns(xml: &str) -> String {
+    let bytes = xml.as_bytes();
+    let mut out = String::with_capacity(xml.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'<' {
+            let next = xml[i..]
+                .find('<')
+                .map(|offset| i + offset)
+                .unwrap_or(xml.len());
+            out.push_str(&xml[i..next]);
+            i = next;
+            continue;
+        }
+        let mut j = i + 1;
+        let mut closing = false;
+        if j < bytes.len() && bytes[j] == b'/' {
+            closing = true;
+            j += 1;
+        }
+        let name_start = j;
+        while j < bytes.len() {
+            let c = bytes[j];
+            if c.is_ascii_alphanumeric() || c == b'_' || c == b'-' || c == b'.' || c == b':' {
+                j += 1;
+            } else {
+                break;
+            }
+        }
+        let name = &xml[name_start..j];
+        if name.is_empty() {
+            let end = xml[i..]
+                .find('>')
+                .map(|offset| i + offset + 1)
+                .unwrap_or(xml.len());
+            out.push_str(&xml[i..end]);
+            i = end;
+            continue;
+        }
+        out.push('<');
+        if closing {
+            out.push('/');
+        }
+        if let Some(pos) = name.find(':') {
+            out.push_str(&name[pos + 1..]);
+        } else {
+            out.push_str(name);
+        }
+        i = j;
+    }
+    out
 }
 
 #[frb]

--- a/script/build_linux_deb.dart
+++ b/script/build_linux_deb.dart
@@ -152,7 +152,10 @@ Future<String> _assembleDebRoot({
     await root.delete(recursive: true);
   }
 
-  // 1. bundle
+  // 1. bundle（先建 opt 父目录：cp -r src dst 要求 dst 的父目录存在，
+  //    且 dst 不存在时才会把内容拷成 dst 本身）
+  final optDir = Directory('$staging${sep}opt');
+  await optDir.create(recursive: true);
   await _run('cp', ['-r', bundlePath, debRoot], cwd: projectRoot);
   // 2. /usr/bin 符号链接
   final binDir = Directory('$staging${sep}usr${sep}bin');

--- a/script/build_linux_deb.dart
+++ b/script/build_linux_deb.dart
@@ -238,9 +238,14 @@ int _installedSize(String debRoot) {
   return total;
 }
 
-/// 用 dpkg-shlibdeps 从 ELF 自动推导运行时依赖。
 Future<List<String>> _resolveShlibDeps(String staging, String bundlePath) async {
+  final debianDir = Directory('$staging${Platform.pathSeparator}debian');
   try {
+    await debianDir.create(recursive: true);
+    await File('${debianDir.path}${Platform.pathSeparator}control').writeAsString(
+      'Package: breeze\n',
+    );
+
     final mainBinary = '$bundlePath/breeze';
     final soFiles = Directory('$bundlePath/lib')
         .listSync()
@@ -272,6 +277,10 @@ Future<List<String>> _resolveShlibDeps(String staging, String bundlePath) async 
       color: _yellow,
     );
     return const [];
+  } finally {
+    if (debianDir.existsSync()) {
+      await debianDir.delete(recursive: true);
+    }
   }
 }
 

--- a/script/build_linux_deb.dart
+++ b/script/build_linux_deb.dart
@@ -189,9 +189,7 @@ Future<void> _writeControl({
   final debianDir = Directory('$debRoot${Platform.pathSeparator}DEBIAN');
   await debianDir.create(recursive: true);
 
-  final depends = shlibDeps.isEmpty
-      ? ''
-      : '\nDepends: ${shlibDeps.join(', ')}\n';
+  final depends = shlibDeps.isEmpty ? '' : 'Depends: ${shlibDeps.join(', ')}\n';
 
   await File('${debianDir.path}${Platform.pathSeparator}control').writeAsString(
     'Package: breeze\n'
@@ -201,11 +199,11 @@ Future<void> _writeControl({
     'Architecture: $architecture\n'
     'Maintainer: Breeze Developers <dev@breeze.app>\n'
     'Installed-Size: ${_installedSize(debRoot)}\n'
+    '$depends'
     'Description: Third-party client for Bika and JM comics\n'
     ' A modern, feature-rich Flutter client for reading comics from\n'
     ' Bika (哔咔) and JM (禁漫), with built-in upscaling, plugins and\n'
     ' desktop system-tray support.\n'
-    '$depends',
   );
 
   final postinst = '''#!/bin/sh

--- a/script/build_linux_deb.dart
+++ b/script/build_linux_deb.dart
@@ -152,8 +152,7 @@ Future<String> _assembleDebRoot({
     await root.delete(recursive: true);
   }
 
-  // 1. bundle（先建 opt 父目录：cp -r src dst 要求 dst 的父目录存在，
-  //    且 dst 不存在时才会把内容拷成 dst 本身）
+  // 1. bundle
   final optDir = Directory('$staging${sep}opt');
   await optDir.create(recursive: true);
   await _run('cp', ['-r', bundlePath, debRoot], cwd: projectRoot);

--- a/script/build_linux_deb.dart
+++ b/script/build_linux_deb.dart
@@ -1,0 +1,345 @@
+#!/usr/bin/env dart
+// ignore_for_file: avoid_print
+//
+// Breeze Linux .deb 构建脚本
+//
+// 用法:
+//   dart ./script/build_linux_deb.dart            # flutter build linux --release 后打 deb
+//   dart ./script/build_linux_deb.dart --package-only  # 复用已有 bundle，只打 deb
+//
+// 环境变量:
+//   SENTRY_DSN       存在时注入 --dart-define=sentry_dsn
+//   OUTPUT_DIR       默认 build-deb
+//   VERSION          覆盖版本号(默认取 pubspec.yaml version)
+//
+// 依赖 dpkg-dev(dpkg-shlibdeps / dpkg-deb)，在 Debian/Ubuntu CI 上可直接运行。
+
+import 'dart:convert';
+import 'dart:io';
+
+const String _green = '\x1B[32m';
+const String _cyan = '\x1B[36m';
+const String _yellow = '\x1B[33m';
+const String _red = '\x1B[31m';
+const String _reset = '\x1B[0m';
+
+void _log(String message, {String color = _cyan}) {
+  print('$color$message$_reset');
+}
+
+Never _fail(String message, {int code = 1}) {
+  _log(message, color: _red);
+  exit(code);
+}
+
+Future<void> _run(
+  String executable,
+  List<String> arguments, {
+  required String cwd,
+  Map<String, String>? environment,
+}) async {
+  _log('> $executable ${arguments.join(' ')}');
+  final process = await Process.start(
+    executable,
+    arguments,
+    workingDirectory: cwd,
+    environment: environment,
+    runInShell: true,
+  );
+
+  process.stdout.transform(utf8.decoder).listen(stdout.write);
+  process.stderr.transform(utf8.decoder).listen(stderr.write);
+  final exitCode = await process.exitCode;
+  if (exitCode != 0) {
+    _fail(
+      'Command failed with exit code $exitCode: $executable ${arguments.join(' ')}',
+    );
+  }
+}
+
+Future<String> _runCapture(
+  String executable,
+  List<String> arguments, {
+  required String cwd,
+}) async {
+  final result = await Process.run(
+    executable,
+    arguments,
+    workingDirectory: cwd,
+    runInShell: true,
+  );
+  if (result.exitCode != 0) {
+    _fail(
+      'Command failed with exit code ${result.exitCode}: '
+      '$executable ${arguments.join(' ')}\n${result.stderr}',
+    );
+  }
+  return (result.stdout as String).trim();
+}
+
+String _projectRoot() {
+  final scriptFile = File.fromUri(Platform.script);
+  return Directory(scriptFile.parent.path).parent.path;
+}
+
+/// 从 pubspec.yaml 读取版本，形如 3.0.30+2218 -> 3.0.30（deb 上游版本不允许 +）
+Future<String> _readDebVersion(String projectRoot) async {
+  final envVersion = Platform.environment['VERSION']?.trim() ?? '';
+  if (envVersion.isNotEmpty) {
+    return envVersion.replaceAll(RegExp(r'\+.*$'), '');
+  }
+  final pubspec = await File(
+    '$projectRoot${Platform.pathSeparator}pubspec.yaml',
+  ).readAsString();
+  final match = RegExp(
+    r'^version:\s*([0-9]+\.[0-9]+\.[0-9]+)(?:\+(\d+))?',
+    multiLine: true,
+  ).firstMatch(pubspec);
+  if (match == null) {
+    _fail('Cannot parse version from pubspec.yaml');
+  }
+  return match.group(1)!;
+}
+
+Future<void> _buildLinuxRelease(String projectRoot) async {
+  final env = Map<String, String>.from(Platform.environment);
+  final sentryDsn = env['SENTRY_DSN']?.trim() ?? '';
+
+  final args = <String>[
+    'build',
+    'linux',
+    '--release',
+    '--split-debug-info=${projectRoot}${Platform.pathSeparator}build${Platform.pathSeparator}symbols',
+  ];
+  if (sentryDsn.isNotEmpty) {
+    args.add('--dart-define=sentry_dsn=$sentryDsn');
+    _log('Detected SENTRY_DSN, injecting dart-define.', color: _green);
+  }
+
+  await _run('flutter', args, cwd: projectRoot);
+
+  final crashpad = File(
+    '$projectRoot${Platform.pathSeparator}build${Platform.pathSeparator}linux'
+    '${Platform.pathSeparator}x64${Platform.pathSeparator}release'
+    '${Platform.pathSeparator}bundle${Platform.pathSeparator}lib'
+    '${Platform.pathSeparator}crashpad_handler',
+  );
+  if (!await crashpad.exists()) {
+    _fail('Missing required file: ${crashpad.path}');
+  }
+  await _run('chmod', ['+x', crashpad.path], cwd: projectRoot);
+}
+
+/// 布局:
+///   /opt/breeze/<bundle>
+///   /usr/bin/breeze -> ../../opt/breeze/breeze
+///   /usr/share/applications/io.github.windy.breeze.desktop
+///   /usr/share/icons/hicolor/512x512/apps/io.github.windy.breeze.png
+Future<String> _assembleDebRoot({
+  required String projectRoot,
+  required String bundlePath,
+  required String version,
+}) async {
+  final sep = Platform.pathSeparator;
+  final outputDir =
+      Platform.environment['OUTPUT_DIR']?.trim().isNotEmpty == true
+          ? Platform.environment['OUTPUT_DIR']!.trim()
+          : 'build-deb';
+  final staging = '$projectRoot${sep}${outputDir}${sep}package';
+  final debRoot = '$staging${sep}opt${sep}breeze';
+  final root = Directory(staging);
+  if (root.existsSync()) {
+    await root.delete(recursive: true);
+  }
+
+  // 1. bundle
+  await _run('cp', ['-r', bundlePath, debRoot], cwd: projectRoot);
+  // 2. /usr/bin 符号链接
+  final binDir = Directory('$staging${sep}usr${sep}bin');
+  await binDir.create(recursive: true);
+  await Link(
+    '$staging${sep}usr${sep}bin${sep}breeze',
+  ).create('../../opt/breeze/breeze');
+  // 3. desktop 入口
+  final appsDir = Directory('$staging${sep}usr${sep}share${sep}applications');
+  await appsDir.create(recursive: true);
+  await File('$projectRoot${sep}flatpak${sep}io.github.windy.breeze.desktop')
+      .copy('${appsDir.path}${sep}io.github.windy.breeze.desktop');
+  // 4. 图标(复用应用图标，512x512)
+  final iconsDir = Directory(
+    '$staging${sep}usr${sep}share${sep}icons${sep}hicolor'
+    '${sep}512x512${sep}apps',
+  );
+  await iconsDir.create(recursive: true);
+  await File('$projectRoot${sep}asset${sep}image${sep}app-icon.png').copy(
+    '${iconsDir.path}${sep}io.github.windy.breeze.png',
+  );
+
+  return staging;
+}
+
+Future<void> _writeControl({
+  required String debRoot,
+  required String version,
+  required String architecture,
+  required List<String> shlibDeps,
+}) async {
+  final debianDir = Directory('$debRoot${Platform.pathSeparator}DEBIAN');
+  await debianDir.create(recursive: true);
+
+  final depends = shlibDeps.isEmpty
+      ? ''
+      : '\nDepends: ${shlibDeps.join(', ')}\n';
+
+  await File('${debianDir.path}${Platform.pathSeparator}control').writeAsString(
+    'Package: breeze\n'
+    'Version: $version\n'
+    'Section: net\n'
+    'Priority: optional\n'
+    'Architecture: $architecture\n'
+    'Maintainer: Breeze Developers <dev@breeze.app>\n'
+    'Installed-Size: ${_installedSize(debRoot)}\n'
+    'Description: Third-party client for Bika and JM comics\n'
+    ' A modern, feature-rich Flutter client for reading comics from\n'
+    ' Bika (哔咔) and JM (禁漫), with built-in upscaling, plugins and\n'
+    ' desktop system-tray support.\n'
+    '$depends',
+  );
+
+  final postinst = '''#!/bin/sh
+set -e
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+  gtk-update-icon-cache -f -t /usr/share/icons/hicolor >/dev/null 2>&1 || true
+fi
+if command -v update-desktop-database >/dev/null 2>&1; then
+  update-desktop-database -q /usr/share/applications || true
+fi
+exit 0
+''';
+  await File(
+    '${debianDir.path}${Platform.pathSeparator}postinst',
+  ).writeAsString(postinst);
+  await File(
+    '${debianDir.path}${Platform.pathSeparator}postrm',
+  ).writeAsString(postinst.replaceFirst('postinst', 'postrm'));
+  await _run('chmod', ['755', '${debianDir.path}/postinst'], cwd: debianDir.path);
+  await _run('chmod', ['755', '${debianDir.path}/postrm'], cwd: debianDir.path);
+}
+
+int _installedSize(String debRoot) {
+  var total = 0;
+  for (final entity in Directory(debRoot).listSync(recursive: true)) {
+    if (entity is File) {
+      total += entity.lengthSync() ~/ 1024;
+    }
+  }
+  return total;
+}
+
+/// 用 dpkg-shlibdeps 从 ELF 自动推导运行时依赖。
+Future<List<String>> _resolveShlibDeps(String staging, String bundlePath) async {
+  try {
+    final mainBinary = '$bundlePath/breeze';
+    final soFiles = Directory('$bundlePath/lib')
+        .listSync()
+        .whereType<File>()
+        .map((f) => f.path)
+        .where((p) => p.endsWith('.so') || p.contains('.so.'))
+        .toList();
+
+    final output = await _runCapture(
+      'dpkg-shlibdeps',
+      ['-O', mainBinary, ...soFiles],
+      cwd: staging,
+    );
+    final line = output
+        .split('\n')
+        .firstWhere((l) => l.startsWith('shlibs:Depends='), orElse: () => '');
+    if (line.isEmpty) {
+      _log('dpkg-shlibdeps produced no Depends line.', color: _yellow);
+      return const [];
+    }
+    return line
+        .substring('shlibs:Depends='.length)
+        .split(',')
+        .map((e) => e.trim())
+        .toList();
+  } catch (e) {
+    _log(
+      'dpkg-shlibdeps unavailable, deb will carry no Depends. Detail: $e',
+      color: _yellow,
+    );
+    return const [];
+  }
+}
+
+Future<void> main(List<String> args) async {
+  if (!Platform.isLinux) {
+    _fail('This script only supports Linux.');
+  }
+
+  final projectRoot = _projectRoot();
+  final version = await _readDebVersion(projectRoot);
+  final outputDir =
+      Platform.environment['OUTPUT_DIR']?.trim().isNotEmpty == true
+          ? Platform.environment['OUTPUT_DIR']!.trim()
+          : 'build-deb';
+  final sep = Platform.pathSeparator;
+  final bundlePath =
+      '$projectRoot${sep}build${sep}linux${sep}x64${sep}release${sep}bundle';
+
+  final packageOnly = args.contains('--package-only');
+
+  _log('=== Breeze Linux .deb Build ===', color: _green);
+  _log('Project root: $projectRoot', color: _green);
+  _log('Version: $version', color: _green);
+
+  if (!packageOnly) {
+    await _buildLinuxRelease(projectRoot);
+  } else {
+    _log('--package-only: reuse existing bundle at $bundlePath', color: _yellow);
+  }
+  if (!Directory(bundlePath).existsSync()) {
+    _fail('Build bundle not found: $bundlePath');
+  }
+
+  final staging = await _assembleDebRoot(
+    projectRoot: projectRoot,
+    bundlePath: bundlePath,
+    version: version,
+  );
+
+  final shlibDeps = await _resolveShlibDeps(staging, bundlePath);
+  if (shlibDeps.isNotEmpty) {
+    _log('Resolved runtime deps:\n  ${shlibDeps.join('\n  ')}', color: _cyan);
+  }
+
+  final archResult = await _runCapture(
+    'dpkg',
+    ['--print-architecture'],
+    cwd: projectRoot,
+  );
+  final architecture = archResult.isEmpty ? 'amd64' : archResult;
+
+  await _writeControl(
+    debRoot: staging,
+    version: version,
+    architecture: architecture,
+    shlibDeps: shlibDeps,
+  );
+
+  final debFile = File(
+    '$projectRoot${sep}${outputDir}${sep}breeze_${version}_$architecture.deb',
+  );
+  await _run(
+    'dpkg-deb',
+    ['--build', '--root-owner-group', staging, debFile.path],
+    cwd: projectRoot,
+  );
+
+  final size = (await debFile.length()) / 1024 / 1024;
+  _log(
+    'deb package created: ${debFile.path} (${size.toStringAsFixed(1)} MB)',
+    color: _green,
+  );
+}

--- a/script/build_linux_deb.dart
+++ b/script/build_linux_deb.dart
@@ -1,18 +1,5 @@
 #!/usr/bin/env dart
 // ignore_for_file: avoid_print
-//
-// Breeze Linux .deb 构建脚本
-//
-// 用法:
-//   dart ./script/build_linux_deb.dart            # flutter build linux --release 后打 deb
-//   dart ./script/build_linux_deb.dart --package-only  # 复用已有 bundle，只打 deb
-//
-// 环境变量:
-//   SENTRY_DSN       存在时注入 --dart-define=sentry_dsn
-//   OUTPUT_DIR       默认 build-deb
-//   VERSION          覆盖版本号(默认取 pubspec.yaml version)
-//
-// 依赖 dpkg-dev(dpkg-shlibdeps / dpkg-deb)，在 Debian/Ubuntu CI 上可直接运行。
 
 import 'dart:convert';
 import 'dart:io';
@@ -82,7 +69,6 @@ String _projectRoot() {
   return Directory(scriptFile.parent.path).parent.path;
 }
 
-/// 从 pubspec.yaml 读取版本，形如 3.0.30+2218 -> 3.0.30（deb 上游版本不允许 +）
 Future<String> _readDebVersion(String projectRoot) async {
   final envVersion = Platform.environment['VERSION']?.trim() ?? '';
   if (envVersion.isNotEmpty) {
@@ -130,11 +116,6 @@ Future<void> _buildLinuxRelease(String projectRoot) async {
   await _run('chmod', ['+x', crashpad.path], cwd: projectRoot);
 }
 
-/// 布局:
-///   /opt/breeze/<bundle>
-///   /usr/bin/breeze -> ../../opt/breeze/breeze
-///   /usr/share/applications/io.github.windy.breeze.desktop
-///   /usr/share/icons/hicolor/512x512/apps/io.github.windy.breeze.png
 Future<String> _assembleDebRoot({
   required String projectRoot,
   required String bundlePath,
@@ -152,22 +133,18 @@ Future<String> _assembleDebRoot({
     await root.delete(recursive: true);
   }
 
-  // 1. bundle
   final optDir = Directory('$staging${sep}opt');
   await optDir.create(recursive: true);
   await _run('cp', ['-r', bundlePath, debRoot], cwd: projectRoot);
-  // 2. /usr/bin 符号链接
   final binDir = Directory('$staging${sep}usr${sep}bin');
   await binDir.create(recursive: true);
   await Link(
     '$staging${sep}usr${sep}bin${sep}breeze',
   ).create('../../opt/breeze/breeze');
-  // 3. desktop 入口
   final appsDir = Directory('$staging${sep}usr${sep}share${sep}applications');
   await appsDir.create(recursive: true);
   await File('$projectRoot${sep}flatpak${sep}io.github.windy.breeze.desktop')
       .copy('${appsDir.path}${sep}io.github.windy.breeze.desktop');
-  // 4. 图标(复用应用图标，512x512)
   final iconsDir = Directory(
     '$staging${sep}usr${sep}share${sep}icons${sep}hicolor'
     '${sep}512x512${sep}apps',

--- a/script/build_linux_deb.dart
+++ b/script/build_linux_deb.dart
@@ -243,7 +243,7 @@ Future<List<String>> _resolveShlibDeps(String staging, String bundlePath) async 
   try {
     await debianDir.create(recursive: true);
     await File('${debianDir.path}${Platform.pathSeparator}control').writeAsString(
-      'Package: breeze\n',
+      'Source: breeze\nPackage: breeze\nArchitecture: any\n',
     );
 
     final mainBinary = '$bundlePath/breeze';


### PR DESCRIPTION

### 1. Linux 系统托盘与窗口关闭行为
- `lib/platform/desktop/system_tray.dart`：补完 Linux/macOS 托盘支持——Flatpak 沙箱内改用清单图标名（`io.github.windy.breeze`）修复图标不显示；`setToolTip` 后移并单独 try/catch（Linux 端未实现该 API 会抛异常）；新增 `showMainWindow()`，macOS/Linux 走 `window_manager`，去掉对 user32 的 `NativeWindow.show()` 依赖。
- `lib/main.dart`：Linux 点 X 恢复尊重关闭设置（隐藏到托盘 / 关闭 / 询问），之前是直接强制退出。
- `lib/widgets/desktop/custom_title_bar.dart`：根因修复——自绘标题栏的 X 在 Linux 下直接调 `exit(0)` 秒杀进程，完全绕过关闭设置与托盘逻辑；现改走 `windowManager.close()`，与 macOS/Windows 同一路关闭决策。
- `linux/runner/my_application.cc`：原生层接管 `delete_event`（先隐藏窗口再经 `breeze/linux/window` 通道通知 Dart，避免新版 Flutter 下点 X 直接退出）；header bar 改在 `realize` 之前设置，消除 `gtk_window_set_titlebar() called on a realized window` 警告。

### 2. WebDAV 修复
- `rust/src/api/webdav.rs`：修复手搓 PROPFIND 实现的 XML 解析问题——`serde_xml_rs` 解析不了带命名空间前缀的响应标签（如 `<d:response>`），连接测试报 `missing field 'response'`、同步失败。现反序列化前剥离标签命名空间前缀。

### 3. Linux .deb 打包
- 新增 `script/build_linux_deb.dart`：`flutter build linux --release` 后打 `.deb`（`--package-only` 可复用已有 bundle；`Depends` 由 `dpkg-shlibdeps` 自动扫描；打包时临时生成小写 `debian/control` 满足 `dpkg-shlibdeps` 要求，打完清理）。
- `.github/workflows/push-build.yml`：`build-linux` job 追加 deb 构建并上传 `linux-deb` artifact。

## 测试
- Flatpak 实测：关闭行为选「隐藏到托盘」时点 X，窗口隐藏、托盘图标保留、进程存活；快捷键关闭与标题栏 X 行为一致。
- WebDAV：带命名空间前缀的 PROPFIND 响应解析通过，连接测试恢复正常。
- CI：`build-linux`（flatpak + deb）构建通过。