### PR TITLE
fix(about): 修复贡献者列表获取失败

### DIFF
--- a/lib/page/about/view/about_page.dart
+++ b/lib/page/about/view/about_page.dart
@@ -3,6 +3,7 @@ import 'package:material_ui/material_ui.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:zephyr/i18n/strings.g.dart';
 import 'package:zephyr/main.dart';
+import 'package:zephyr/network/utils/github_proxy.dart';
 
 import 'package:zephyr/service/update/check_update.dart';
 
@@ -47,25 +48,37 @@ class _AboutPageState extends State<AboutPage> {
   }
 
   Future<void> _fetchContributors() async {
+    const repoPath = '/repos/deretame/Breeze/contributors';
+    final urls = [
+      ...mirrorBaseUrls.map((base) => '${base}https://api.github.com$repoPath'),
+      'https://api.github.com$repoPath',
+    ];
     try {
-      final response = await fetch(
-        'https://api.github.com/repos/deretame/Breeze/contributors',
-        headers: const {
-          'User-Agent': 'Breeze',
-          'Accept': 'application/vnd.github+json',
-        },
-        query: {'per_page': 20},
-      );
-
-      if (response.ok && mounted) {
-        final data = response.json;
-        setState(() {
-          _contributors = List<Map<String, dynamic>>.from(
-            data is List ? data : const [],
+      for (final url in urls) {
+        try {
+          final response = await fetch(
+            url,
+            headers: const {
+              'User-Agent': 'Breeze',
+              'Accept': 'application/vnd.github+json',
+            },
+            query: {'per_page': 20},
           );
-          _contributorsLoading = false;
-        });
-      } else if (mounted) {
+          if (response.ok && mounted) {
+            final data = response.json;
+            setState(() {
+              _contributors = List<Map<String, dynamic>>.from(
+                data is List ? data : const [],
+              );
+              _contributorsLoading = false;
+            });
+            return;
+          }
+        } catch (_) {
+          continue;
+        }
+      }
+      if (mounted) {
         setState(() {
           _contributorsError = t.about.fetchFailed;
           _contributorsLoading = false;

--- a/lib/page/about/view/about_page.dart
+++ b/lib/page/about/view/about_page.dart
@@ -50,6 +50,10 @@ class _AboutPageState extends State<AboutPage> {
     try {
       final response = await fetch(
         'https://api.github.com/repos/deretame/Breeze/contributors',
+        headers: const {
+          'User-Agent': 'Breeze',
+          'Accept': 'application/vnd.github+json',
+        },
         query: {'per_page': 20},
       );
 


### PR DESCRIPTION
## 问题

关于页的贡献者列表经常刷不出来（显示获取失败），两个叠加原因：

1. 请求没带 `User-Agent`，GitHub API 对无 UA 请求直接回 403；
2. 即使带了 UA，未认证接口 60 次/小时/IP 的限流在国内共用出口下几分钟就烧完，照样 403。

## 改动（lib/page/about/view/about_page.dart）

- 补 `User-Agent: Breeze` + `Accept: application/vnd.github+json`；
- 照抄版本更新检查的多通道回退：gh-proxy 镜像挨个试，全挂才直连（已逐个验证返回标准 GitHub JSON，解析逻辑不用动）。

## 验证

- 空 UA 调接口复现 403；带 UA + Accept 返回 200；
- 本机出口限流耗尽（remaining: 0）时，三个镜像通道均返回 200。